### PR TITLE
Node and Typescript saving secrets in .env

### DIFF
--- a/Blogs/Managing secrets with BOT files in Bot Framework v4.md
+++ b/Blogs/Managing secrets with BOT files in Bot Framework v4.md
@@ -113,10 +113,8 @@ For Node/TypeScript, secrets are managed via the `DotEnv` NPM package which is i
 You can create a `.env` file which contains the secrets as follows:
 
 ```json
-  {
-    "botFilePath": "./YourBotFile.bot",
-    "botFileSecret": "Your MSBot secret, something like zOku/rKiFRa/ISohbv3/1O6k7rhGEsXdV+lAO/8mVBU="
-  }
+  botFilePath = "./YourBotFile.bot",
+  botFileSecret = "Your MSBot secret, something like zOku/rKiFRa/ISohbv3/1O6k7rhGEsXdV+lAO/8mVBU="
 ```
 
 You can then read the secrets as follows:

--- a/Blogs/Managing secrets with BOT files in Bot Framework v4.md
+++ b/Blogs/Managing secrets with BOT files in Bot Framework v4.md
@@ -113,7 +113,7 @@ For Node/TypeScript, secrets are managed via the `DotEnv` NPM package which is i
 You can create a `.env` file which contains the secrets as follows:
 
 ```json
-  botFilePath = "./YourBotFile.bot",
+  botFilePath = YourBotFile.bot
   botFileSecret = "Your MSBot secret, something like zOku/rKiFRa/ISohbv3/1O6k7rhGEsXdV+lAO/8mVBU="
 ```
 


### PR DESCRIPTION
Hi Martin, 
reading about .Bot files in your blog (thank you for the blog post first of all!), I stumbled about the formatting of the .env file in NodeJs/Typescript. Testing it, I found that dotenv won't accept the json formatting and will result in the `const env `being undefined.
The proposed format is working for me and is documented here: [https://github.com/motdotla/dotenv](https://github.com/motdotla/dotenv) . 
Thanks and greetings, Jakob